### PR TITLE
Add google services json to CI

### DIFF
--- a/.github/composite/setup/action.yml
+++ b/.github/composite/setup/action.yml
@@ -1,5 +1,14 @@
 name: 'Setup Java and Gradle'
-description: 'Sets up Java 21 and gradle for use in actual tasks'
+description: 'Sets up Java, gradle, and API secrets for use in actual tasks'
+
+inputs:
+  GOOGLE_SERVICES_JSON:
+    description: 'Base64 encoded google-services.json from secrets'
+    required: true
+  GOOGLE_CLIENT_ID:
+    description: 'GOOGLE_CLIENT_ID from secrets'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -11,4 +20,14 @@ runs:
         cache: gradle
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+      shell: bash
+    - name: Create Google Services JSON File
+      env:
+        GOOGLE_SERVICES_JSON: ${{ inputs.GOOGLE_SERVICES_JSON }}
+      run: echo $GOOGLE_SERVICES_JSON | base64 -di > ./app/google-services.json
+      shell: bash
+    - name: Create keys.properties
+      env:
+        GOOGLE_CLIENT_ID: ${{ inputs.GOOGLE_CLIENT_ID }}
+      run: echo "GOOGLE_CLIENT_ID=\"$GOOGLE_CLIENT_ID\"" > keys.properties
       shell: bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,6 +18,9 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle-
     - uses: ./.github/composite/setup
+      with:
+        GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     - name: Build the project (no tests, no lint etc)
       run: ./gradlew assemble
 
@@ -27,6 +30,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/composite/setup
+      with:
+        GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     - name: Lint with Gradle
       run: ./gradlew lint
 
@@ -36,6 +42,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/composite/setup
+      with:
+        GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     - name: Spotless with Gradle
       run: ./gradlew spotlessCheck
 
@@ -45,6 +54,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/composite/setup
+      with:
+        GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
     - name: Test with Gradle
       run: ./gradlew test
 


### PR DESCRIPTION
This should enable the CI to assemble our app without forcing us to commit google services json.

I have added my own google services into the secrets and CI will be using this one. Try not to commit any tests that use firebase or similar, otherwise CI will end up exhausting all the limits