### PR TITLE
Fix missing transition on registration happy path

### DIFF
--- a/app/src/main/java/com/example/evently/ui/auth/AuthActivity.java
+++ b/app/src/main/java/com/example/evently/ui/auth/AuthActivity.java
@@ -161,7 +161,11 @@ public class AuthActivity extends AppCompatActivity {
 
                 // If user is not found, create an account for them with the new info
                 Account newAccount = new Account(email, name, Optional.ofNullable(phone), email);
-                accountDB.storeAccount(newAccount);
+                accountDB.storeAccount(newAccount, v -> successfulTransition(), e -> {
+                    Log.e("AuthActivity", e.toString());
+                    Toast.makeText(this, "Something went wrong...", Toast.LENGTH_SHORT)
+                            .show();
+                });
             }
         }
     }


### PR DESCRIPTION
There was a missing transition. Perhaps it was accidentally removed during a merge.

At the moment, builds in `main` cause users to not transition into EntrantActivity after succesful registration. Furthermore, sometimes their account is not stored into firestore either. This might fix the latter too - but I have got a fleeting feeling that there's something deeper going wrong here.

I'm pretty sure I know how to fix it though. And it just so happens to be something that will get rid of all this callback hell.